### PR TITLE
Infra de produção: Caddy SSL, deploy SSH, pipelines simplificadas

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -81,25 +81,3 @@ jobs:
       - name: Run tests
         run: pytest backend/tests/ -v --cov=backend/app --cov-report=term-missing
 
-  # ── Build Docker image ───────────────────────────────────────────────────
-  build:
-    name: Build Docker Image
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build backend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: infra/docker/backend.prod.Dockerfile
-          push: false
-          tags: cloudatlas-backend:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,75 +1,51 @@
-name: Deploy to Azure
+name: Deploy to Azure VM
 
 on:
-  workflow_run:
-    workflows: ["Backend CI", "Frontend CI"]
-    types: [completed]
+  push:
     branches: [main]
 
 env:
-  ACR_REGISTRY: ${{ secrets.ACR_LOGIN_SERVER }}
-  RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-  APP_NAME: cloudatlas
+  VM_HOST: ${{ secrets.VM_HOST }}
+  VM_USER: cloudatlas
+  APP_DIR: /app/cloud-hub-manager
 
 jobs:
   deploy:
-    name: Build, Push & Deploy
+    name: Deploy
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
       - uses: actions/checkout@v4
 
-      # ── Azure Login ────────────────────────────────────────────────────────
-      - name: Login to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      # ── Setup SSH ─────────────────────────────────────────────────────────
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VM_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ env.VM_HOST }} >> ~/.ssh/known_hosts
 
-      # ── Login to Azure Container Registry ──────────────────────────────────
-      - name: Login to ACR
-        uses: azure/docker-login@v2
-        with:
-          login-server: ${{ secrets.ACR_LOGIN_SERVER }}
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_PASSWORD }}
+      # ── Pull latest code ──────────────────────────────────────────────────
+      - name: Pull latest code on VM
+        run: |
+          ssh ${{ env.VM_USER }}@${{ env.VM_HOST }} \
+            "cd ${{ env.APP_DIR }} && git pull origin main"
 
-      # ── Build & Push Backend ───────────────────────────────────────────────
-      - name: Build & push backend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: infra/docker/backend.prod.Dockerfile
-          push: true
-          tags: |
-            ${{ env.ACR_REGISTRY }}/cloudatlas-backend:${{ github.sha }}
-            ${{ env.ACR_REGISTRY }}/cloudatlas-backend:latest
+      # ── Rebuild & restart containers ──────────────────────────────────────
+      - name: Rebuild & restart containers
+        run: |
+          ssh ${{ env.VM_USER }}@${{ env.VM_HOST }} \
+            "cd ${{ env.APP_DIR }}/infra && docker compose -f docker-compose.prod.yml up --build -d"
 
-      # ── Build & Push Frontend ──────────────────────────────────────────────
-      - name: Build & push frontend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: infra/docker/frontend.prod.Dockerfile
-          push: true
-          tags: |
-            ${{ env.ACR_REGISTRY }}/cloudatlas-frontend:${{ github.sha }}
-            ${{ env.ACR_REGISTRY }}/cloudatlas-frontend:latest
+      # ── Health check ──────────────────────────────────────────────────────
+      - name: Health check
+        run: |
+          sleep 30
+          ssh ${{ env.VM_USER }}@${{ env.VM_HOST }} \
+            "curl -sf http://localhost:8000/health || exit 1"
 
-      # ── Deploy to Azure App Service ────────────────────────────────────────
-      - name: Deploy backend to Azure App Service
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: ${{ env.APP_NAME }}-backend
-          images: ${{ env.ACR_REGISTRY }}/cloudatlas-backend:${{ github.sha }}
-
-      - name: Deploy frontend to Azure App Service
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: ${{ env.APP_NAME }}-frontend
-          images: ${{ env.ACR_REGISTRY }}/cloudatlas-frontend:${{ github.sha }}
-
-      # ── Logout ─────────────────────────────────────────────────────────────
-      - name: Azure logout
-        run: az logout
-        if: always()
+      # ── Cleanup old images ────────────────────────────────────────────────
+      - name: Cleanup old images
+        run: |
+          ssh ${{ env.VM_USER }}@${{ env.VM_HOST }} \
+            "docker image prune -f"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -67,25 +67,3 @@ jobs:
           path: frontend/dist
           retention-days: 7
 
-  # ── Build Docker image ───────────────────────────────────────────────────
-  docker:
-    name: Build Docker Image
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build frontend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: infra/docker/frontend.prod.Dockerfile
-          push: false
-          tags: cloudatlas-frontend:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,6 +1,24 @@
 version: '3.8'
 
 services:
+  # ── Caddy (HTTPS reverse proxy + auto SSL) ──────────────────────────────────
+  caddy:
+    image: caddy:2-alpine
+    container_name: cloudatlas-caddy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - cloudatlas-network
+    depends_on:
+      frontend:
+        condition: service_started
+    restart: unless-stopped
+
   # ── Database ─────────────────────────────────────────────────────────────────
   postgres:
     image: postgres:16-alpine
@@ -30,7 +48,7 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-cloudhub}:${POSTGRES_PASSWORD:-cloudhub_pass}@postgres:5432/${POSTGRES_DB:-cloudhub_db}
       - SECRET_KEY=${SECRET_KEY:-changeme-use-openssl-rand-hex-32-in-production}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
-      - 'ALLOWED_ORIGINS=["http://localhost","http://localhost:3000","http://localhost:8000"]'
+      - 'ALLOWED_ORIGINS=["https://cloudatlas.app.br","https://www.cloudatlas.app.br","http://localhost","http://localhost:3000"]'
       - DEBUG=False
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       # Cloud credentials
@@ -48,7 +66,7 @@ services:
       - SMTP_PASSWORD=${SMTP_PASSWORD:-}
       - SMTP_FROM=${SMTP_FROM:-noreply@cloudatlas.io}
       - SMTP_USE_TLS=${SMTP_USE_TLS:-True}
-      - FRONTEND_URL=${FRONTEND_URL:-http://localhost}
+      - FRONTEND_URL=${FRONTEND_URL:-https://cloudatlas.app.br}
       # OAuth (SSO)
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
@@ -74,9 +92,10 @@ services:
     build:
       context: ..
       dockerfile: infra/docker/frontend.prod.Dockerfile
+      args:
+        VITE_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+        VITE_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
     container_name: cloudatlas-frontend
-    ports:
-      - "${FRONTEND_PORT:-80}:80"
     networks:
       - cloudatlas-network
     depends_on:
@@ -91,8 +110,6 @@ services:
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
-    ports:
-      - "9090:9090"
     networks:
       - cloudatlas-network
     restart: unless-stopped
@@ -114,8 +131,6 @@ services:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
-    ports:
-      - "3001:3000"
     networks:
       - cloudatlas-network
     depends_on:
@@ -130,3 +145,5 @@ volumes:
   postgres_data:
   prometheus_data:
   grafana_data:
+  caddy_data:
+  caddy_config:

--- a/infra/docker/Caddyfile
+++ b/infra/docker/Caddyfile
@@ -1,0 +1,15 @@
+cloudatlas.app.br {
+    # API + backend endpoints
+    reverse_proxy /api/* backend:8000
+    reverse_proxy /health backend:8000
+    reverse_proxy /metrics backend:8000
+    reverse_proxy /docs backend:8000
+    reverse_proxy /openapi.json backend:8000
+
+    # Frontend (nginx serving static SPA)
+    reverse_proxy /* frontend:80
+}
+
+www.cloudatlas.app.br {
+    redir https://cloudatlas.app.br{uri} permanent
+}

--- a/infra/docker/frontend.prod.Dockerfile
+++ b/infra/docker/frontend.prod.Dockerfile
@@ -3,6 +3,12 @@ FROM node:20-alpine AS build
 
 WORKDIR /app
 
+# Build args for Vite env vars (baked into static bundle)
+ARG VITE_GOOGLE_CLIENT_ID=""
+ARG VITE_GITHUB_CLIENT_ID=""
+ENV VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID
+ENV VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID
+
 COPY frontend/package*.json ./
 RUN npm ci
 

--- a/infra/docker/nginx.conf
+++ b/infra/docker/nginx.conf
@@ -25,26 +25,7 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # ── API proxy → backend ──────────────────────────────────────────────────
-    location /api/ {
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 120s;
-    }
-
-    # ── Health/metrics proxy ─────────────────────────────────────────────────
-    location /health {
-        proxy_pass http://backend:8000;
-    }
-
-    location /metrics {
-        proxy_pass http://backend:8000;
-    }
-
-    # ── SPA fallback ─────────────────────────────────────────────────────────
+    # ── SPA fallback (API proxy handled by Caddy in production) ─────────────────────────────────────────────────────────
     location / {
         try_files $uri $uri/ /index.html;
 


### PR DESCRIPTION
- Adiciona Caddyfile como reverse proxy com SSL automático (Let's Encrypt)
- Atualiza docker-compose.prod.yml: Caddy, CORS, VITE build args, remove portas expostas
- Simplifica nginx.conf: remove proxy /api (Caddy cuida), mantém SPA
- Adiciona VITE_ build args no frontend.prod.Dockerfile
- Reescreve deploy.yml para SSH deploy direto na VM Azure
- Remove jobs Docker build dos pipelines de CI (backend.yml, frontend.yml)