### PR TITLE
cd: deploy em produção com aprovação manual, healthcheck e rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ name: CI
 # Jobs INFORMATIVOS (continue-on-error — não bloqueiam ainda):
 #   - frontend-quality: eslint + vitest (promover a bloqueante após configurar
 #                       o ambiente jsdom do vitest e zerar os warnings do eslint)
+#
+# CD (deploy-prod): só em push na main, após os 4 bloqueantes passarem E após
+# aprovação manual no Environment "production". Faz healthcheck e, se falhar,
+# executa rollback automático para o commit anterior.
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
@@ -131,3 +135,103 @@ jobs:
       - name: vitest
         working-directory: frontend
         run: npm test
+
+  # ── CD: deploy em produção (VM Azure, docker compose) ───────────────────────
+  # Só roda em push na main (pós-merge), SOMENTE se os 4 jobs bloqueantes
+  # passaram (needs), e AINDA assim aguarda aprovação manual — o GitHub pausa
+  # aqui até um revisor aprovar no Environment "production".
+  #
+  # Secrets necessários (Settings → Secrets and variables → Actions):
+  #   SSH_PRIVATE_KEY : chave privada com acesso à VM (a pública vai no
+  #                     ~/.ssh/authorized_keys do servidor)
+  #   SSH_HOST        : IP ou hostname da VM
+  #   SSH_USER        : usuário SSH
+  #   DEPLOY_PATH     : caminho do repositório no servidor (ex: /opt/cloudatlas)
+  #   SSH_PORT        : (opcional) porta SSH — assume 22 se não definido
+  # Variável opcional (aba Variables):
+  #   HEALTH_URL      : URL do healthcheck (default: https://hub.cloudatlas.app.br/health)
+  deploy-prod:
+    needs: [backend-tests, migrations, frontend-build, docker-build]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production   # ← exige aprovação manual (configurar reviewers)
+    steps:
+      - name: Preparar chave SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H -p "${{ secrets.SSH_PORT || 22 }}" "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      # Guarda o commit atualmente em produção — é para ele que voltamos se algo falhar.
+      - name: Capturar versão atual (ponto de rollback)
+        id: prev
+        run: |
+          SHA=$(ssh -i ~/.ssh/deploy_key -p "${{ secrets.SSH_PORT || 22 }}" \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+            "cd '${{ secrets.DEPLOY_PATH }}' && git rev-parse HEAD")
+          echo "Versão atual em produção: $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy (git pull + docker compose up)
+        id: deploy
+        run: |
+          ssh -i ~/.ssh/deploy_key -p "${{ secrets.SSH_PORT || 22 }}" \
+            -o StrictHostKeyChecking=yes \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+            "set -e && \
+             cd '${{ secrets.DEPLOY_PATH }}' && \
+             git fetch --all --prune && \
+             git checkout main && \
+             git pull origin main && \
+             docker compose -f infra/docker-compose.prod.yml up -d --build && \
+             docker image prune -f"
+
+      - name: Smoke test (/health)
+        id: health
+        run: |
+          URL="${{ vars.HEALTH_URL || 'https://hub.cloudatlas.app.br/health' }}"
+          echo "Verificando $URL"
+          for i in $(seq 1 15); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$URL" || true)
+            echo "tentativa $i: HTTP $code"
+            if [ "$code" = "200" ]; then echo "Aplicação saudável."; exit 0; fi
+            sleep 10
+          done
+          echo "::error::Healthcheck não retornou 200 após o deploy."
+          exit 1
+
+      # ── Rollback automático ───────────────────────────────────────────────
+      # Dispara se o deploy OU o healthcheck falharem: volta o código para o
+      # commit anterior e reconstrói.
+      #
+      # ⚠️ LIMITAÇÃO IMPORTANTE: isto reverte o CÓDIGO, não o BANCO. Se o deploy
+      # aplicou uma migration (o entrypoint roda `alembic upgrade head`), o schema
+      # continua na versão nova enquanto o código volta para a antiga. Para deploys
+      # com migration destrutiva, faça restore do backup manualmente.
+      - name: Rollback para a versão anterior
+        if: failure() && steps.prev.outputs.sha != ''
+        run: |
+          echo "::warning::Deploy falhou — revertendo para ${{ steps.prev.outputs.sha }}"
+          ssh -i ~/.ssh/deploy_key -p "${{ secrets.SSH_PORT || 22 }}" \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+            "set -e && \
+             cd '${{ secrets.DEPLOY_PATH }}' && \
+             git checkout ${{ steps.prev.outputs.sha }} && \
+             docker compose -f infra/docker-compose.prod.yml up -d --build"
+
+      - name: Verificar saúde após rollback
+        if: failure() && steps.prev.outputs.sha != ''
+        run: |
+          URL="${{ vars.HEALTH_URL || 'https://hub.cloudatlas.app.br/health' }}"
+          for i in $(seq 1 15); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$URL" || true)
+            echo "pós-rollback tentativa $i: HTTP $code"
+            if [ "$code" = "200" ]; then
+              echo "::notice::Rollback concluído — produção restaurada na versão anterior."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Rollback executado mas a aplicação segue fora do ar. Intervenção manual necessária."
+          exit 1


### PR DESCRIPTION
## O que faz

Adiciona o job `deploy-prod` ao workflow de CI, fechando o ciclo CI/CD.

### Fluxo
1. Roda **somente** em push na \`main\` (pós-merge)
2. Só existe se os 4 jobs bloqueantes passarem (\`needs\`)
3. **Pausa aguardando aprovação manual** (Environment \`production\`)
4. Deploy via SSH: \`git pull\` + \`docker compose -f infra/docker-compose.prod.yml up -d --build\`
5. **Healthcheck** no \`/health\` (até 2,5 min)
6. **Rollback automático** para o commit anterior se o deploy ou o healthcheck falharem, seguido de nova verificação de saúde

### Secrets necessários
\`SSH_PRIVATE_KEY\`, \`SSH_HOST\`, \`SSH_USER\`, \`DEPLOY_PATH\` (e \`SSH_PORT\` opcional).
Variável opcional: \`HEALTH_URL\`.

### Limitação conhecida
O rollback reverte o **código**, não o **banco**. Como o entrypoint roda \`alembic upgrade head\`, uma migration aplicada permanece após o rollback. Deploys com migration destrutiva exigem restore manual do backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)